### PR TITLE
Use a different name for local and instance variable.

### DIFF
--- a/jcache-javaee/src/main/java/javax/enterprise/cache/spi/CacheExposer.java
+++ b/jcache-javaee/src/main/java/javax/enterprise/cache/spi/CacheExposer.java
@@ -40,10 +40,10 @@ public class CacheExposer {
 
     public void init(@Observes @Initialized(ApplicationScoped.class) Object doesntMatter) {
         this.caches = new HashMap<>();
-        CachesMetaData caches = CachesProvider.getCacheUnits();
-        this.cachingProvider = Caching.getCachingProvider(caches.getCachingProviderClass());
+        CachesMetaData cachesMetaData = CachesProvider.getCacheUnits();
+        this.cachingProvider = Caching.getCachingProvider(cachesMetaData.getCachingProviderClass());
         this.cacheManager = cachingProvider.getCacheManager();
-        this.caches = createCaches(caches.getCaches());
+        this.caches = createCaches(cachesMetaData.getCaches());
 
     }
 


### PR DESCRIPTION
cache was used both as an instance and a local variable.